### PR TITLE
Update build.rs to use cc crate, replaces gcc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "geodesic"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Boris Pfahringer <bpnzltd@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
-    gcc::compile_library("libgeodesic.a", &["src/geodesic.c"]);
+    cc::Build::new()
+        .file("src/geodesic.c")
+        .compile("libgeodesic.a");
 }


### PR DESCRIPTION
Updated build.rs to use the cc crate which has replaced the gcc
crate for building C libraries.